### PR TITLE
Added U to filterAminoAcidSequenceString

### DIFF
--- a/src/filterAminoAcidSequenceString.js
+++ b/src/filterAminoAcidSequenceString.js
@@ -5,8 +5,8 @@ module.exports = function filterAminoAcidSequenceString(
 ) {
   options = options || {};
   if (options.includeStopCodon) {
-    return sequenceString.replace(/[^xtgalmfwkqespvicyhrnd\.]/gi, "");
+    return sequenceString.replace(/[^xtgalmfwkqespvicyhrndu\.]/gi, "");
   }
   // ac.throw(ac.string, sequenceString);
-  return sequenceString.replace(/[^xtgalmfwkqespvicyhrnd]/gi, "");
+  return sequenceString.replace(/[^xtgalmfwkqespvicyhrndu]/gi, "");
 };


### PR DESCRIPTION
Hello @tnrich !
 
To validation of a sequence with **U** to be successful, **u** should be added to regexp in _filterAminoAcidSequenceString_

Continuing issue https://github.com/TeselaGen/ve-sequence-utils/issues/5