### PR TITLE
fix undefined global in browser

### DIFF
--- a/src/featureTypesAndColors.js
+++ b/src/featureTypesAndColors.js
@@ -103,7 +103,7 @@ const getMergedFeatureMap = () => {
   );
   let featureOverrides =
     (typeof window !== "undefined" && get(window, "tg_featureTypeOverrides")) ||
-    get(global, "tg_featureTypeOverrides");
+    (typeof global !== "undefined" && get(global, "tg_featureTypeOverrides"));
 
   featureOverrides = featureOverrides || [];
   featureOverrides = featureOverrides.map(fo => {

--- a/src/tidyUpAnnotation.js
+++ b/src/tidyUpAnnotation.js
@@ -95,7 +95,8 @@ module.exports = function tidyUpAnnotation(
         allowNonStandardGenbankTypes ||
         (typeof window !== "undefined" &&
           get(window, "tg_allowNonStandardGenbankTypes")) ||
-        get(global, "tg_allowNonStandardGenbankTypes")
+        (typeof global !== "undefined" &&
+          get(global, "tg_allowNonStandardGenbankTypes"))
       )
         return true;
       return false;


### PR DESCRIPTION
Hi @tnrich,

This is a fix for throwing errors when global is not defined and trying to get values from it using lodash.

The browser does not have global and when previous get parameter from window returns undefined, the code will crash.

Best.